### PR TITLE
refactor: StudyPost 삭제 기능 Soft Delete 적용

### DIFF
--- a/src/main/java/com/studycrew/studyBoard/converter/StudyApplicationConverter.java
+++ b/src/main/java/com/studycrew/studyBoard/converter/StudyApplicationConverter.java
@@ -40,6 +40,8 @@ public class StudyApplicationConverter {
     public static MyStudyApplicationResponse toUserApplications(StudyApplication studyApplication) {
         return MyStudyApplicationResponse.builder()
                 .applicationStatus(studyApplication.getApplicationStatus())
+                .studyStatus(studyApplication.getStudyPost().getStudyStatus())
+                .deleted(studyApplication.getStudyPost().isDeleted())
                 .appliedAt(studyApplication.getCreatedAt())
                 .studyPostId(studyApplication.getStudyPost().getId())
                 .studyApplicationId(studyApplication.getId())

--- a/src/main/java/com/studycrew/studyBoard/dto/StudyApplicationDTO/StudyApplicationResponseDTO.java
+++ b/src/main/java/com/studycrew/studyBoard/dto/StudyApplicationDTO/StudyApplicationResponseDTO.java
@@ -40,6 +40,8 @@ public class StudyApplicationResponseDTO {
         private Long studyApplicationId;
         private Long studyPostId;
         private String studyTitle;
+        private StudyStatus studyStatus;
+        private boolean deleted;
         private ApplicationStatus applicationStatus;
         private LocalDateTime appliedAt;
     }

--- a/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
+++ b/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
@@ -74,4 +74,9 @@ public class StudyPost extends BaseEntity {
         }
         this.acceptedPeople += 1;
     }
+
+    public void delete() {
+        this.deleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
+++ b/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
@@ -47,6 +47,7 @@ public class StudyPost extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private StudyStatus studyStatus;
 
+    @Builder.Default
     private boolean deleted = false;
 
     private LocalDateTime deletedAt;

--- a/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
+++ b/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -45,6 +46,10 @@ public class StudyPost extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private StudyStatus studyStatus;
+
+    private boolean deleted = false;
+
+    private LocalDateTime deletedAt;
 
     public void update(String title, String content) {
         if (title != null) {

--- a/src/main/java/com/studycrew/studyBoard/repository/StudyPostRepository.java
+++ b/src/main/java/com/studycrew/studyBoard/repository/StudyPostRepository.java
@@ -1,6 +1,7 @@
 package com.studycrew.studyBoard.repository;
 
 import com.studycrew.studyBoard.entity.StudyPost;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -10,7 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface StudyPostRepository extends JpaRepository<StudyPost, Long> {
 
-    @Override
+
     @EntityGraph(attributePaths = {"user"})
-    Page<StudyPost> findAll(Pageable pageable);
+    Page<StudyPost> findAllByDeletedFalse(Pageable pageable);
+
+    Optional<StudyPost> findByIdAndDeletedFalse(Long id);
 }

--- a/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
@@ -61,6 +61,11 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
             throw new StudyApplicationHandler(ErrorStatus._STUDY_APPLICATION_FORBIDDEN);
         }
 
+        StudyPost studyPost = studyApplication.getStudyPost();
+        if (studyPost.isDeleted()) {
+            throw new StudyApplicationHandler(ErrorStatus._STUDY_POST_NOT_FOUND);
+        }
+
         studyApplication.reject();
         return studyApplication;
     }

--- a/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
@@ -43,6 +43,11 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
             throw new StudyApplicationHandler(ErrorStatus._STUDY_APPLICATION_FORBIDDEN);
         }
 
+        StudyPost studyPost = studyApplication.getStudyPost();
+        if (studyPost.isDeleted()) {
+            throw new StudyApplicationHandler(ErrorStatus._STUDY_POST_NOT_FOUND);
+        }
+
         studyApplication.approve();
         studyApplication.getStudyPost().increaseAcceptedPeople();
         return studyApplication;

--- a/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
@@ -23,7 +23,7 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
     private final StudyApplicationRepository studyApplicationRepository;
 
     public StudyApplication applyStudyApplication(Long studyPostId, User user){
-        StudyPost studyPost = studyPostRepository.findById(studyPostId)
+        StudyPost studyPost = studyPostRepository.findByIdAndDeletedFalse(studyPostId)
                 .orElseThrow(() -> new StudyPostHandler(ErrorStatus._STUDY_POST_NOT_FOUND));
         if (studyPost.getStudyStatus() == StudyStatus.CLOSED){
             throw new StudyPostHandler(ErrorStatus._STUDY_POST_ALREADY_CLOSED);

--- a/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandServiceImpl.java
@@ -38,7 +38,7 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
 
     @Override
     public StudyPost updateStudyPost(Long studyPostId, User user, StudyPostRequestUpdate dto) {
-        StudyPost studyPost = studyPostRepository.findById(studyPostId)
+        StudyPost studyPost = studyPostRepository.findByIdAndDeletedFalse(studyPostId)
                 .orElseThrow(() -> new StudyPostHandler(ErrorStatus._STUDY_POST_NOT_FOUND));
         if (!studyPost.getUser().getId().equals(user.getId())){
             throw new StudyPostHandler(ErrorStatus._STUDY_POST_FORBIDDEN);

--- a/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandServiceImpl.java
@@ -49,7 +49,7 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
 
     @Override
     public StudyPost closeStudyPost(Long studyPostId, User user) {
-        StudyPost studyPost = studyPostRepository.findById(studyPostId)
+        StudyPost studyPost = studyPostRepository.findByIdAndDeletedFalse(studyPostId)
                 .orElseThrow(() -> new StudyPostHandler(ErrorStatus._STUDY_POST_NOT_FOUND));
         if (!studyPost.getUser().getId().equals(user.getId())){
             throw new StudyPostHandler(ErrorStatus._STUDY_POST_FORBIDDEN);

--- a/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandServiceImpl.java
@@ -33,7 +33,7 @@ public class StudyPostCommandServiceImpl implements StudyPostCommandService {
         if (!studyPost.getUser().getId().equals(user.getId())){
             throw new StudyPostHandler(ErrorStatus._STUDY_POST_FORBIDDEN);
         }
-        studyPostRepository.deleteById(studyPostId);
+        studyPost.delete();
     }
 
     @Override

--- a/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostQueryServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostQueryServiceImpl.java
@@ -21,13 +21,13 @@ public class StudyPostQueryServiceImpl implements StudyPostQueryService {
 
     @Override
     public StudyPost getStudyPost(Long studyPostId) {
-        return studyPostRepository.findById(studyPostId).orElseThrow(() -> new StudyPostHandler(
+        return studyPostRepository.findByIdAndDeletedFalse(studyPostId).orElseThrow(() -> new StudyPostHandler(
                 ErrorStatus._STUDY_POST_NOT_FOUND));
     }
 
     @Override
     public Page<StudyPostResponseDTO.GetStudyPostListResponse> getStudyPostList(Pageable pageable) {
-        return studyPostRepository.findAll(pageable)
+        return studyPostRepository.findAllByDeletedFalse(pageable)
                 .map(StudyPostConverter::toGetStudyPostList);
     }
 }

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -249,6 +249,31 @@ class StudyApplicationCommandServiceImplTest {
         assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
     }
 
+    @Test
+    void 삭제된_스터디글_승인_불가() {
+        // given: 회원, 스터디글 생성
+        User user = getUser();
+        User user2 = getUser2();
+        userRepository.save(user);
+        userRepository.save(user2);
+
+        StudyPost studyPost = getStudyPost(user);
+        studyPostRepository.save(studyPost);
+
+        // when: 스터디글 지원 후 삭제
+        StudyApplication studyApplication = studyApplicationCommandService.applyStudyApplication(studyPost.getId(),
+                user2);
+        studyPostCommandService.deleteStudyPost(studyPost.getId(), user);
+
+        // then: 삭제된 스터디글애 승인시 에러 발생
+        Throwable thrown = catchThrowable(() ->  studyApplicationCommandService.approveStudyApplication(
+                studyApplication.getId(), user));
+        StudyApplicationHandler exception = (StudyApplicationHandler) thrown;
+
+        assertThat(exception.getErrorReason().getCode()).isEqualTo("POST4040");
+        assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
+    }
+
     private static User getUser() {
         return User.builder()
                 .email("이메일@email.com")

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -13,6 +13,7 @@ import com.studycrew.studyBoard.repository.StudyPostRepository;
 import com.studycrew.studyBoard.repository.UserRepository;
 import com.studycrew.studyBoard.service.studyApplication.StudyApplicationCommandService;
 import com.studycrew.studyBoard.service.studyApplication.StudyApplicationQueryService;
+import com.studycrew.studyBoard.service.studyPost.StudyPostCommandService;
 import java.util.List;
 import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,8 @@ class StudyApplicationCommandServiceImplTest {
     private StudyPostRepository studyPostRepository;
     @Autowired
     private StudyApplicationQueryService studyApplicationQueryService;
+    @Autowired
+    private StudyPostCommandService studyPostCommandService;
 
     @Test
     void 스터디_지원하기_테스트(){
@@ -221,6 +224,29 @@ class StudyApplicationCommandServiceImplTest {
         assertThat(exception.getErrorReason().getCode()).isEqualTo("APPLICATION4030");
         assertThat(exception.getErrorReason().getMessage()).contains("스터디 지원에 권한이 없습니다.");
 
+    }
+
+    @Test
+    void 삭제된_스터디글_지원_불가() {
+        // given: 회원, 스터디글 생성
+        User user = getUser();
+        User user2 = getUser2();
+        userRepository.save(user);
+        userRepository.save(user2);
+
+        StudyPost studyPost = getStudyPost(user);
+        studyPostRepository.save(studyPost);
+
+        // when: 스터디글 삭제하기
+        studyPostCommandService.deleteStudyPost(studyPost.getId(), user);
+
+        // then: 삭제된 스터디글애 지원시 에러 발생
+        Throwable thrown = catchThrowable(() ->  studyApplicationCommandService.applyStudyApplication(
+                studyPost.getId(), user2));
+        StudyPostHandler exception = (StudyPostHandler ) thrown;
+
+        assertThat(exception.getErrorReason().getCode()).isEqualTo("POST4040");
+        assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
     }
 
     private static User getUser() {

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -274,6 +274,31 @@ class StudyApplicationCommandServiceImplTest {
         assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
     }
 
+    @Test
+    void 삭제된_스터디글_거절_불가() {
+        // given: 회원, 스터디글 생성
+        User user = getUser();
+        User user2 = getUser2();
+        userRepository.save(user);
+        userRepository.save(user2);
+
+        StudyPost studyPost = getStudyPost(user);
+        studyPostRepository.save(studyPost);
+
+        // when: 스터디글 지원 후 삭제
+        StudyApplication studyApplication = studyApplicationCommandService.applyStudyApplication(studyPost.getId(),
+                user2);
+        studyPostCommandService.deleteStudyPost(studyPost.getId(), user);
+
+        // then: 삭제된 스터디글애 거절시 에러 발생
+        Throwable thrown = catchThrowable(() ->  studyApplicationCommandService.rejectStudyApplication(
+                studyApplication.getId(), user));
+        StudyApplicationHandler exception = (StudyApplicationHandler) thrown;
+
+        assertThat(exception.getErrorReason().getCode()).isEqualTo("POST4040");
+        assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
+    }
+
     private static User getUser() {
         return User.builder()
                 .email("이메일@email.com")

--- a/src/test/java/com/studycrew/studyBoard/service/StudyPostCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyPostCommandServiceImplTest.java
@@ -160,6 +160,31 @@ class StudyPostCommandServiceImplTest {
         assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
     }
 
+    @Test
+    void 삭제된_스터디글_수정_예외() {
+        // given: 회원, 스터디글, 수정 requestDTO 생성
+        User user = getUser();
+        userRepository.save(user);
+        StudyPost studyPost = getStudyPost(user, 1);
+        studyPostRepository.save(studyPost);
+
+        StudyPostRequestUpdate dto = StudyPostRequestUpdate.builder()
+                .title("수정제목")
+                .content("수정글")
+                .build();
+
+        // when: 스터디글 삭제
+        studyPostCommandService.deleteStudyPost(studyPost.getId(), user);
+
+        // then: 삭제된 스터디글에 수정시 예외 발생
+        Throwable thrown = catchThrowable(() ->  studyPostCommandService.updateStudyPost(
+                studyPost.getId(), user, dto));
+        StudyPostHandler exception = (StudyPostHandler) thrown;
+
+        assertThat(exception.getErrorReason().getCode()).isEqualTo("POST4040");
+        assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
+    }
+
     private static User getUser() {
         User user = User.builder()
                 .email("이메일@email.com")

--- a/src/test/java/com/studycrew/studyBoard/service/StudyPostCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyPostCommandServiceImplTest.java
@@ -58,7 +58,16 @@ class StudyPostCommandServiceImplTest {
 
     @Test
     void 스터디글_삭제(){
+        User user = getUser();
+        userRepository.save(user);
 
+        StudyPost studyPost = getStudyPost(user, 1);
+        studyPostRepository.save(studyPost);
+
+        studyPostCommandService.deleteStudyPost(studyPost.getId(), user);
+
+        assertThat(studyPost.isDeleted()).isEqualTo(true);
+        assertThat(studyPost.getDeletedAt()).isNotNull();
     }
 
     @Test
@@ -141,4 +150,14 @@ class StudyPostCommandServiceImplTest {
         return user;
     }
 
+    private static User getUser2() {
+        User user = User.builder()
+                .email("이메일2@email.com")
+                .nickname("닉네임2")
+                .username("이름2")
+                .password("비밀번호2")
+                .role("ROLE_USER")
+                .build();
+        return user;
+    }
 }


### PR DESCRIPTION
### 💡 작업 내용 요약
- 스터디글 삭제 기능을 Soft Delete로 수정했습니다.
- `StudyPost` 엔티티에 `deleted`, `deletedAt` 필드 및 `delete()` 메서드를 추가했습니다.
- 삭제된 스터디글은 단건/목록 조회 시 노출되지 않도록 쿼리 수정했습니다.
- 삭제된 스터디글에 대한 지원/수정/마감/승인/거절 요청을 차단하도록 서비스 로직을 변경했습니다.
- 회원이 지원한 스터디 목록 응답 DTO에 `deleted`와 `studyStatus` 필드를 추가했습니다.
- 관련 테스트 코드를 작성하여 정상 동작하는지 검증했습니다.
