### PR TITLE
feat: 정원 다 찼을 때 스터디 자동 마감 처리

### DIFF
--- a/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
+++ b/src/main/java/com/studycrew/studyBoard/entity/StudyPost.java
@@ -70,10 +70,11 @@ public class StudyPost extends BaseEntity {
     }
 
     public void increaseAcceptedPeople() {
-        if (this.acceptedPeople >= this.maxPeople) {
-            throw new StudyPostHandler(ErrorStatus._STUDY_POST_MAX_CAPACITY_EXCEEDED);
-        }
         this.acceptedPeople += 1;
+    }
+
+    public boolean isFullyBooked() {
+        return this.acceptedPeople >= this.maxPeople;
     }
 
     public void delete() {

--- a/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
@@ -48,8 +48,16 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
             throw new StudyApplicationHandler(ErrorStatus._STUDY_POST_NOT_FOUND);
         }
 
+        if (studyPost.isFullyBooked()) {
+            throw new StudyApplicationHandler(ErrorStatus._STUDY_POST_MAX_CAPACITY_EXCEEDED);
+        }
+
         studyApplication.approve();
         studyApplication.getStudyPost().increaseAcceptedPeople();
+
+        if (studyPost.isFullyBooked()) {
+            studyPost.closeStudyPost();
+        }
         return studyApplication;
     }
 


### PR DESCRIPTION
### 💡 작업 내용 요약
- StudyPost에서 승인된 회원 증가 로직과 정원 초과 검증 로직 분리
- StudyApplicationCommandService에서 스터디 승인 메서드에 초과 검증 및 자동 마감 추가
- 스터디 정원 초과시 자동 마감 테스트 코드
