### PR TITLE
feat: 자신의 글에 지원 불가 및 모집 마감 상태면 승인/거절 불가

### DIFF
--- a/src/main/java/com/studycrew/studyBoard/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/studycrew/studyBoard/apiPayload/code/status/ErrorStatus.java
@@ -37,7 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _STUDY_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "APPLICATION4040", "스터디 지원이 없습니다."),
     _STUDY_APPLICATION_ALREADY_PROCESSED(HttpStatus.CONFLICT, "APPLICATION4091", "이미 처리된 지원입니다."),
     _STUDY_APPLICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "APPLICATION4030", "스터디 지원에 권한이 없습니다."),
-    ;
+    _SELF_APPLICATION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "APPLICATION4031", "자신의 글에는 지원할 수 없습니다." );
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/studycrew/studyBoard/repository/StudyApplicationRepository.java
+++ b/src/main/java/com/studycrew/studyBoard/repository/StudyApplicationRepository.java
@@ -3,6 +3,7 @@ package com.studycrew.studyBoard.repository;
 import com.studycrew.studyBoard.entity.StudyApplication;
 import com.studycrew.studyBoard.entity.StudyPost;
 import com.studycrew.studyBoard.entity.User;
+import com.studycrew.studyBoard.enums.ApplicationStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,4 +13,5 @@ public interface StudyApplicationRepository extends JpaRepository<StudyApplicati
     boolean existsByStudyPostAndUser(StudyPost studyPost, User user);
     List<StudyApplication> findByStudyPostId(Long studyPostId);
     List<StudyApplication> findByUserId(Long userId);
+    List<StudyApplication> findAllByStudyPostAndApplicationStatus(StudyPost studyPost, ApplicationStatus applicationStatus);
 }

--- a/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
@@ -10,6 +10,7 @@ import com.studycrew.studyBoard.entity.User;
 import com.studycrew.studyBoard.enums.StudyStatus;
 import com.studycrew.studyBoard.repository.StudyApplicationRepository;
 import com.studycrew.studyBoard.repository.StudyPostRepository;
+import com.studycrew.studyBoard.service.studyPost.StudyPostCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +22,7 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
 
     private final StudyPostRepository studyPostRepository;
     private final StudyApplicationRepository studyApplicationRepository;
+    private final StudyPostCommandService studyPostCommandService;
 
     public StudyApplication applyStudyApplication(Long studyPostId, User user){
         StudyPost studyPost = studyPostRepository.findByIdAndDeletedFalse(studyPostId)
@@ -59,7 +61,7 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
         studyApplication.getStudyPost().increaseAcceptedPeople();
 
         if (studyPost.isFullyBooked()) {
-            studyPost.closeStudyPost();
+            studyPostCommandService.closeAndRejectPending(studyPost);
         }
         return studyApplication;
     }

--- a/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyApplication/StudyApplicationCommandServiceImpl.java
@@ -31,6 +31,9 @@ public class StudyApplicationCommandServiceImpl implements StudyApplicationComma
         if (studyApplicationRepository.existsByStudyPostAndUser(studyPost, user)) {
             throw new StudyPostHandler(ErrorStatus._STUDY_APPLICATION_ALREADY_EXISTS);
         }
+        if (user.equals(studyPost.getUser())) {
+            throw new StudyApplicationHandler(ErrorStatus._SELF_APPLICATION_NOT_ALLOWED);
+        }
         StudyApplication studyApplication = StudyApplicationConverter.toPendingApplication(studyPost, user);
         return studyApplicationRepository.save(studyApplication);
     }

--- a/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandService.java
+++ b/src/main/java/com/studycrew/studyBoard/service/studyPost/StudyPostCommandService.java
@@ -13,4 +13,6 @@ public interface StudyPostCommandService {
     StudyPost updateStudyPost(Long studyPostId, User user, StudyPostRequestUpdate dto);
 
     StudyPost closeStudyPost(Long studyPostId, User user);
+
+    void closeAndRejectPending(StudyPost studyPost);
 }

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -39,13 +39,15 @@ class StudyApplicationCommandServiceImplTest {
     @Test
     void 스터디_지원하기_테스트(){
         User user = getUser();
+        User user2 = getUser2();
         userRepository.save(user);
+        userRepository.save(user2);
         StudyPost studyPost = getStudyPost(user);
         studyPostRepository.save(studyPost);
         StudyApplication studyApplication = studyApplicationCommandService.applyStudyApplication(studyPost.getId(),
-                user);
+                user2);
         assertThat(studyApplication.getStudyPost()).isEqualTo(studyPost);
-        assertThat(studyApplication.getUser()).isEqualTo(user);
+        assertThat(studyApplication.getUser()).isEqualTo(user2);
         assertThat(studyApplication.getApplicationStatus()).isEqualTo(ApplicationStatus.PENDING);
     }
 

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -327,6 +327,22 @@ class StudyApplicationCommandServiceImplTest {
         assertThat(studyPost.getStudyStatus()).isEqualTo(StudyStatus.CLOSED);
     }
 
+    @Test
+    void 자신의_글에는_지원불가() {
+        User user = getUser();
+        userRepository.save(user);
+
+        StudyPost studyPost = getStudyPost(user);
+        studyPostRepository.save(studyPost);
+
+        Throwable thrown = catchThrowable(() ->  studyApplicationCommandService.applyStudyApplication(
+                studyPost.getId(), user));
+        StudyApplicationHandler exception = (StudyApplicationHandler) thrown;
+
+        assertThat(exception.getErrorReason().getCode()).isEqualTo("APPLICATION4031");
+        assertThat(exception.getErrorReason().getMessage()).contains("자신의 글에는 지원할 수 없습니다.");
+    }
+
     private static User getUser() {
         return User.builder()
                 .email("이메일@email.com")

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -54,11 +54,13 @@ class StudyApplicationCommandServiceImplTest {
     @Test
     void 스터디_모집종료_상태_지원_예외발생() {
         User user =  getUser();
+        User user2 = getUser2();
         userRepository.save(user);
+        userRepository.save(user2);
         StudyPost closedStudyPost = getClosedStudyPost(user);
         studyPostRepository.save(closedStudyPost);
         Throwable thrown = catchThrowable(() ->
-                studyApplicationCommandService.applyStudyApplication(closedStudyPost.getId(), user)
+                studyApplicationCommandService.applyStudyApplication(closedStudyPost.getId(), user2)
         );
         assertThat(thrown).isInstanceOf(StudyPostHandler.class);
 

--- a/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyApplicationCommandServiceImplTest.java
@@ -93,12 +93,17 @@ class StudyApplicationCommandServiceImplTest {
     @Test
     void 스터디_중복지원_예외발생() {
         User user = getUser();
+        User user2 = getUser2();
+
         userRepository.save(user);
+        userRepository.save(user2);
+
         StudyPost studyPost = getStudyPost(user);
         studyPostRepository.save(studyPost);
-        studyApplicationCommandService.applyStudyApplication(studyPost.getId(), user);
+
+        studyApplicationCommandService.applyStudyApplication(studyPost.getId(), user2);
         Throwable thrown = catchThrowable(() ->
-                studyApplicationCommandService.applyStudyApplication(studyPost.getId(), user)
+                studyApplicationCommandService.applyStudyApplication(studyPost.getId(), user2)
         );
         StudyPostHandler exception = (StudyPostHandler) thrown;
         assertThat(exception.getErrorReason().getCode()).isEqualTo("APPLICATION4090");

--- a/src/test/java/com/studycrew/studyBoard/service/StudyPostCommandServiceImplTest.java
+++ b/src/test/java/com/studycrew/studyBoard/service/StudyPostCommandServiceImplTest.java
@@ -6,11 +6,14 @@ import com.studycrew.studyBoard.apiPayload.exception.handler.StudyPostHandler;
 import com.studycrew.studyBoard.dto.StudyPostDTO.StudyPostRequestDTO;
 import com.studycrew.studyBoard.dto.StudyPostDTO.StudyPostRequestDTO.StudyPostRequestUpdate;
 import com.studycrew.studyBoard.dto.StudyPostDTO.StudyPostResponseDTO.GetStudyPostListResponse;
+import com.studycrew.studyBoard.entity.StudyApplication;
 import com.studycrew.studyBoard.entity.StudyPost;
 import com.studycrew.studyBoard.entity.User;
+import com.studycrew.studyBoard.enums.ApplicationStatus;
 import com.studycrew.studyBoard.enums.StudyStatus;
 import com.studycrew.studyBoard.repository.StudyPostRepository;
 import com.studycrew.studyBoard.repository.UserRepository;
+import com.studycrew.studyBoard.service.studyApplication.StudyApplicationCommandService;
 import com.studycrew.studyBoard.service.studyPost.StudyPostCommandService;
 import com.studycrew.studyBoard.service.studyPost.StudyPostQueryService;
 import static org.assertj.core.api.Assertions.*;
@@ -35,6 +38,8 @@ class StudyPostCommandServiceImplTest {
     StudyPostRepository studyPostRepository;
     @Autowired
     StudyPostQueryService studyPostQueryService;
+    @Autowired
+    StudyApplicationCommandService studyApplicationCommandService;
 
     @Test
     void 스터디글_생성(){
@@ -183,6 +188,25 @@ class StudyPostCommandServiceImplTest {
 
         assertThat(exception.getErrorReason().getCode()).isEqualTo("POST4040");
         assertThat(exception.getErrorReason().getMessage()).contains("스터디글이 없습니다.");
+    }
+
+    @Test
+    void 모집마감시_처리안된_지원_자동거절() {
+        User user = getUser();
+        User user2 = getUser2();
+
+        userRepository.save(user);
+        userRepository.save(user2);
+
+        StudyPost studyPost = getStudyPost(user, 1);
+        studyPostRepository.save(studyPost);
+
+        StudyApplication studyApplication = studyApplicationCommandService.applyStudyApplication(studyPost.getId(),
+                user2);
+        studyPostCommandService.closeStudyPost(studyPost.getId(), user);
+
+        assertThat(studyApplication.getApplicationStatus()).isEqualTo(ApplicationStatus.REJECTED);
+
     }
 
     private static User getUser() {


### PR DESCRIPTION
### 💡 작업 내용 요약
- 자신의 글에는 지원할 수 없게 합니다. 
- 모집 마감시 진행중인 처리 안된 지원을 모두 자동 거절 상태로 변경합니다.
- 지원 승인 후 정원이 모두 찼을 시 자동으로 모집 마감 상태로 바꾸고, 처리 안된 지원을 모두 자동 거절 상태로 변경합니다. 